### PR TITLE
Fix Pages workflow: split jobs and align action versions

### DIFF
--- a/.github/workflows/deno-ci.yaml
+++ b/.github/workflows/deno-ci.yaml
@@ -8,11 +8,11 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -24,15 +24,22 @@ jobs:
 
       - name: Build site
         run: deno task build
-      
+
       - name: Setup Pages
-        uses: actions/configure-pages@v3
-      
+        uses: actions/configure-pages@v5
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
           path: '_site'
 
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Issue

The Pages deploy step failed with:

```
Error: Failed to create deployment (status: 404) with build version ...
Error: HttpError: Cannot find any run with github.run_id 24621644752.
```

The workflow had incompatible action versions:
- `configure-pages@v3`
- `upload-pages-artifact@v4`
- `deploy-pages@v1`

`deploy-pages@v1` cannot read the artifact format produced by `upload-pages-artifact@v4` — the API endpoints and signed-URL handling changed across major versions.

## Fix

- **Split into `build` and `deploy` jobs** — the recommended pattern in GitHub's Pages docs. The `deploy` job depends on `build`.
- **Added `environment: github-pages`** to the deploy job — required by `deploy-pages@v4+` so the deployment is associated with the Pages environment.
- **Upgraded action versions** so they're all compatible:
  - `configure-pages@v3` → `v5`
  - `upload-pages-artifact@v4` (kept)
  - `deploy-pages@v1` → `v5`
- **Added `actions: read` permission** — required by `deploy-pages@v4+`.

## Note

If the deploy still fails after this PR, check that **GitHub Pages is enabled** with **"GitHub Actions"** as the source under repo Settings → Pages.

## Test plan

- [ ] Merge to `main` and confirm the workflow runs both jobs successfully
- [ ] Verify Pages deployment URL serves the rebuilt site

https://claude.ai/code/session_011dGyHWVawXfmFwkqU2HrVT