### PR TITLE
Add Motion.dev animations, profile image, and dark portfolio theme

### DIFF
--- a/_includes/layout.vto
+++ b/_includes/layout.vto
@@ -14,7 +14,7 @@
       <img src="/assets/img/devin-ai1.webp" alt="Devin Bess" class="avatar">
       <div class="profile-text">
         <span class="profile-name">Devin Bess</span>
-        <span class="profile-tagline">SRE &middot; Go &middot; Rust &middot; Observability</span>
+        <span class="profile-tagline">SRE &middot; Observability</span>
       </div>
     </div>
   </header>

--- a/_includes/layout.vto
+++ b/_includes/layout.vto
@@ -2,9 +2,25 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{{ title }}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/assets/css/main.css">
 </head>
 <body>
-  {{ content }}
+  <header class="site-header" id="site-header">
+    <div class="profile">
+      <img src="/assets/img/devin-ai1.webp" alt="Devin Bess" class="avatar">
+      <div class="profile-text">
+        <span class="profile-name">Devin Bess</span>
+        <span class="profile-tagline">SRE &middot; Go &middot; Rust &middot; Observability</span>
+      </div>
+    </div>
+  </header>
+  <main class="content">
+    {{ content }}
+  </main>
+  <script type="module" src="/assets/js/animations.js"></script>
 </body>
 </html>

--- a/_includes/projects-section.vto
+++ b/_includes/projects-section.vto
@@ -1,12 +1,12 @@
-<section id="projects">
-  <h2>Projects</h2>
+<section id="projects" class="section">
+  <h2 class="section-title">Projects</h2>
   <div class="projects-grid">
     {{ for project of projects }}
       <div class="project-card">
-        <h3>{{ project.name }}</h3>
-        <p>{{ project.description }}</p>
+        <h3 class="project-name">{{ project.name }}</h3>
+        <p class="project-desc">{{ project.description }}</p>
         {{ if project.url }}
-          <a href="{{ project.url }}" target="_blank" rel="noopener">View Project</a>
+          <a href="{{ project.url }}" class="project-link" target="_blank" rel="noopener">View ↗</a>
         {{ /if }}
       </div>
     {{ /for }}

--- a/_includes/skills-section.vto
+++ b/_includes/skills-section.vto
@@ -1,10 +1,10 @@
-<section id="skills">
-  <h2>Skills</h2>
+<section id="skills" class="section">
+  <h2 class="section-title">Skills</h2>
   <div class="skills-grid">
     {{ for group of skills }}
-      <div class="skill-category">
-        <h3>{{ group.category }}</h3>
-        <ul>
+      <div class="skill-card">
+        <h3 class="skill-category">{{ group.category }}</h3>
+        <ul class="skill-list">
           {{ for item of group.items }}
             <li>{{ item }}</li>
           {{ /for }}

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,216 @@
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+:root {
+  --bg: #0d0d0d;
+  --surface: #161616;
+  --border: #252525;
+  --accent: #6ee7b7;
+  --accent-dim: rgba(110, 231, 183, 0.12);
+  --text: #e5e5e5;
+  --muted: #777;
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', monospace;
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-sans);
+  font-size: 1rem;
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+/* ── Header ─────────────────────────────────────── */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: rgba(13, 13, 13, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+  padding: 0.75rem 2rem;
+  opacity: 0;
+  transform: translateY(-20px);
+}
+
+.profile {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--accent);
+  flex-shrink: 0;
+}
+
+.profile-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.profile-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+
+.profile-tagline {
+  font-size: 0.75rem;
+  color: var(--muted);
+  font-family: var(--font-mono);
+}
+
+/* ── Content ─────────────────────────────────────── */
+.content {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 2rem 6rem;
+}
+
+/* ── Hero ────────────────────────────────────────── */
+.hero {
+  padding: 5rem 0 4rem;
+  opacity: 0;
+  transform: translateY(30px);
+}
+
+.hero-heading {
+  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: #fff;
+  margin-bottom: 1.25rem;
+}
+
+.hero-sub {
+  font-size: 1.05rem;
+  color: var(--muted);
+  max-width: 560px;
+  line-height: 1.75;
+}
+
+/* ── Sections ────────────────────────────────────── */
+.section {
+  padding: 3.5rem 0;
+  border-top: 1px solid var(--border);
+  opacity: 0;
+  transform: translateY(30px);
+}
+
+.section-title {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 2rem;
+}
+
+/* ── Skills ──────────────────────────────────────── */
+.skills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.skill-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.25rem;
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+.skill-category {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--accent);
+  font-family: var(--font-mono);
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.05em;
+}
+
+.skill-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.skill-list li {
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.skill-list li::before {
+  content: '›  ';
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* ── Projects ────────────────────────────────────── */
+.projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.project-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: border-color 0.2s ease;
+}
+
+.project-card:hover { border-color: var(--accent); }
+
+.project-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.project-desc {
+  font-size: 0.85rem;
+  color: var(--muted);
+  flex: 1;
+}
+
+.project-link {
+  font-size: 0.8rem;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  text-decoration: none;
+  margin-top: 0.25rem;
+  align-self: flex-start;
+}
+
+.project-link:hover { text-decoration: underline; }
+
+/* ── Responsive ──────────────────────────────────── */
+@media (max-width: 600px) {
+  .site-header { padding: 0.65rem 1rem; }
+  .content { padding: 0 1rem 4rem; }
+  .hero { padding: 3rem 0 2.5rem; }
+}

--- a/assets/js/animations.js
+++ b/assets/js/animations.js
@@ -1,0 +1,42 @@
+import { animate, stagger, inView } from "https://cdn.jsdelivr.net/npm/motion@latest/+esm";
+
+// Header slides down on load
+animate(
+  "#site-header",
+  { opacity: [0, 1], y: [-20, 0] },
+  { duration: 0.5, easing: "ease-out" }
+);
+
+// Hero fades up on load (slight delay so header lands first)
+animate(
+  ".hero",
+  { opacity: [0, 1], y: [30, 0] },
+  { duration: 0.65, delay: 0.2, easing: [0.25, 0.1, 0.25, 1] }
+);
+
+// Sections fade up as they scroll into view
+inView(".section", ({ target }) => {
+  animate(
+    target,
+    { opacity: [0, 1], y: [30, 0] },
+    { duration: 0.55, easing: "ease-out" }
+  );
+});
+
+// Skill cards stagger in when section enters view
+inView("#skills", () => {
+  animate(
+    ".skill-card",
+    { opacity: [0, 1], y: [20, 0] },
+    { duration: 0.4, delay: stagger(0.08, { start: 0.1 }), easing: "ease-out" }
+  );
+});
+
+// Project cards stagger in when section enters view
+inView("#projects", () => {
+  animate(
+    ".project-card",
+    { opacity: [0, 1], y: [20, 0] },
+    { duration: 0.4, delay: stagger(0.1, { start: 0.1 }), easing: "ease-out" }
+  );
+});

--- a/index.vto
+++ b/index.vto
@@ -4,7 +4,7 @@ title: Devin Bess — Portfolio
 ---
 <section class="hero" id="hero">
   <h1 class="hero-heading">Building reliable systems<br>at scale.</h1>
-  <p class="hero-sub">Site reliability engineer focused on observability, distributed systems, and developer tooling. I write Go, Rust, and Python, and I care deeply about keeping things running.</p>
+  <p class="hero-sub">Architect, Senior Site Reliability Engineer focused on observability, distributed systems, and developer tooling. I write Python, Bash, IaC and I care deeply about keeping things running.</p>
 </section>
 {{ include "skills-section.vto" }}
 {{ include "projects-section.vto" }}

--- a/index.vto
+++ b/index.vto
@@ -1,7 +1,10 @@
 ---
 layout: layout.vto
-title: Devin's Portfolio
+title: Devin Bess — Portfolio
 ---
-<h1>Welcome to my portfolio</h1>
+<section class="hero" id="hero">
+  <h1 class="hero-heading">Building reliable systems<br>at scale.</h1>
+  <p class="hero-sub">Site reliability engineer focused on observability, distributed systems, and developer tooling. I write Go, Rust, and Python, and I care deeply about keeping things running.</p>
+</section>
 {{ include "skills-section.vto" }}
 {{ include "projects-section.vto" }}


### PR DESCRIPTION
## Summary

- **Profile image** — sticky frosted-glass header with `devin-ai1.webp` as a circular avatar in the top-left, alongside name and tagline
- **Dark theme** — `#0d0d0d` background, teal (`#6ee7b7`) accent, Inter + JetBrains Mono fonts, responsive card grids for skills and projects
- **Motion.dev animations** (loaded via CDN ESM, zero build-step overhead):
  - Header slides down on page load
  - Hero text fades up with a short delay
  - Skills and projects sections fade up as they scroll into view (`inView`)
  - Skill and project cards stagger in sequentially when their section enters the viewport
- **Hero section** — bold heading + bio copy replaces the bare `# Welcome to my portfolio`

## Test plan

- [ ] Merge and confirm CI builds successfully
- [ ] Visit the deployed Pages URL — header avatar appears top-left
- [ ] Scroll down — sections and cards animate in on entry
- [ ] Resize to mobile — layout stays readable

https://claude.ai/code/session_011dGyHWVawXfmFwkqU2HrVT