### PR TITLE
Rename Writing section to Good Reads

### DIFF
--- a/_includes/articles-section.vto
+++ b/_includes/articles-section.vto
@@ -1,5 +1,5 @@
 <section id="articles" class="section" aria-labelledby="articles-title">
-  <h2 class="section-title" id="articles-title">Writing</h2>
+  <h2 class="section-title" id="articles-title">Good Reads</h2>
   <div class="articles-list">
     {{ for article of articles }}
       <article class="article-card">

--- a/_includes/layout.vto
+++ b/_includes/layout.vto
@@ -32,7 +32,7 @@
     <nav class="site-nav" aria-label="Primary">
       <a href="#skills">Skills</a>
       <a href="#projects">Projects</a>
-      <a href="#articles">Writing</a>
+      <a href="#articles">Good Reads</a>
       <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Toggle color theme">
         <span class="theme-icon" aria-hidden="true">◐</span>
       </button>


### PR DESCRIPTION
## Summary
- Renames the nav link label from \"Writing\" to \"Good Reads\" (`_includes/layout.vto`)
- Renames the section heading from \"Writing\" to \"Good Reads\" (`_includes/articles-section.vto`)

## Test plan
- [ ] Visit https://devsol.dev and confirm nav shows \"Good Reads\" instead of \"Writing\"
- [ ] Confirm clicking \"Good Reads\" in nav scrolls to the articles section
- [ ] Confirm the section heading reads \"Good Reads\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)